### PR TITLE
Docker multistage build with alpine images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
-FROM java:openjdk-8-jdk
-LABEL maintainer="devops@breakoutevent.onmicrosoft.com"
-
+FROM openjdk:8-jdk-alpine as builder
 RUN mkdir -p /usr/src/myapp
 COPY . /usr/src/myapp
 WORKDIR /usr/src/myapp
-
+RUN apk add --no-cache bash
 RUN ./gradlew stage
-CMD ["java", "-jar", "/usr/src/myapp/app.jar"]
+
+FROM openjdk:8-jre-alpine
+LABEL maintainer="devops@breakoutevent.onmicrosoft.com"
+WORKDIR /usr/src/myapp
+COPY --from=builder /usr/src/myapp/app.jar .
 EXPOSE 8082
+CMD ["java", "-jar", "/usr/src/myapp/app.jar"]


### PR DESCRIPTION
This PR reduced the size of the backend-docker-image from ~1GB to ~130MB