### PR TITLE
Drop unused table media_size to avoid foreign key constrains

### DIFF
--- a/src/main/resources/db/migration/V201805031139__drop_media_size_table.sql
+++ b/src/main/resources/db/migration/V201805031139__drop_media_size_table.sql
@@ -1,0 +1,3 @@
+-- we don't need it anymore and otherwise we will have errors with foreign key constraints on
+-- update of the table `media`
+drop table media_size;


### PR DESCRIPTION
Aus meiner Unterhaltung mit Quincy eben:

> Das Problem ist, dass der Table `media_size` noch existiert, obwohl wir nur noch `media` nutzen. Beim neuen Profilbild Mechanismus wird ein neues media erstellt, und nicht das alte geupdated. Er versucht aber, das alte zu löschen, was nicht geht weil die media_sizes noch dranhängen. Daher geht dann alles verloren :wink:
> Wenn ich machen würden `drop table media_size` dann sollte es gehen

Ich denke den Table brauchen wir nicht mehr, wir haben ja die größten Sizes migriert? Und sollten wir das ganze mal analysieren wollen können wir immer noch unsere Backups ansehen?

Was meinst du Piwo?