### PR TITLE
Offline sponsoring

### DIFF
--- a/src/main/java/backend/controller/ChallengeController.kt
+++ b/src/main/java/backend/controller/ChallengeController.kt
@@ -161,6 +161,7 @@ class ChallengeController(private var challengeService: ChallengeService,
                     view.sponsorIsHidden = true
                 }
                 view.unregisteredSponsor?.address = null
+                view.unregisteredSponsor?.email = null
             }
 
             challenge.sponsor.let {

--- a/src/main/java/backend/controller/ChallengeController.kt
+++ b/src/main/java/backend/controller/ChallengeController.kt
@@ -10,6 +10,7 @@ import backend.model.event.TeamService
 import backend.model.posting.PostingService
 import backend.model.sponsoring.UnregisteredSponsor
 import backend.model.user.Sponsor
+import backend.model.user.Participant
 import backend.model.user.User
 import backend.model.user.UserService
 import backend.services.ConfigurationService
@@ -129,10 +130,46 @@ class ChallengeController(private var challengeService: ChallengeService,
      * Get all challenges for a team
      */
     @GetMapping("/event/{eventId}/team/{teamId}/challenge/")
-    fun getAllChallengesForTeam(@PathVariable teamId: Long): Iterable<ChallengeView> {
-        return challengeService.findByTeamId(teamId).map {
-            val view = ChallengeView(it)
-            view.unregisteredSponsor?.address = null // Set address to null to make it non public
+    fun getAllChallengesForTeam(@AuthenticationPrincipal customUserDetails: CustomUserDetails?,
+                                @PathVariable teamId: Long): Iterable<ChallengeView> {
+        val team = teamService.findOne(teamId) ?: throw NotFoundException("No team with id $teamId found")
+
+        return if (customUserDetails != null) getAllChallengesAuthenticated(customUserDetails, team)
+        else getAllChallengesUnauthenticated(team)
+    }
+
+
+    private fun getAllChallengesAuthenticated(customUserDetails: CustomUserDetails, team: Team): Iterable<ChallengeView> {
+
+        val user = userService.getUserFromCustomUserDetails(customUserDetails)
+        val participant = user.getRole(Participant::class)
+
+        if (participant != null && team.isMember(participant)) {
+            return challengeService.findByTeamId(team.id!!).map(::ChallengeView)
+        } else {
+            throw UnauthorizedException("Only members of the team ${team.id} can view its challenges")
+        }
+    }
+
+    private fun getAllChallengesUnauthenticated(team: Team): Iterable<ChallengeView> {
+        return challengeService.findByTeamId(team.id!!).map { challenge ->
+            val view = ChallengeView(challenge)
+
+            challenge.sponsor.unregisteredSponsor?.let {
+                if (it.isHidden) {
+                    view.unregisteredSponsor = null
+                    view.sponsorIsHidden = true
+                }
+                view.unregisteredSponsor?.address = null
+            }
+
+            challenge.sponsor.let {
+                if (it.isHidden) {
+                    view.sponsorId = null
+                    view.sponsorIsHidden = true
+                }
+            }
+
             return@map view
         }
     }

--- a/src/main/java/backend/controller/ChallengeController.kt
+++ b/src/main/java/backend/controller/ChallengeController.kt
@@ -93,7 +93,6 @@ class ChallengeController(private var challengeService: ChallengeService,
                 firstname = unregisteredSponsor.firstname!!,
                 lastname = unregisteredSponsor.lastname!!,
                 company = unregisteredSponsor.company!!,
-                gender = unregisteredSponsor.gender!!,
                 email = unregisteredSponsor.email,
                 address = unregisteredSponsor.address!!.toAddress()!!,
                 isHidden = unregisteredSponsor.isHidden)

--- a/src/main/java/backend/controller/ChallengeController.kt
+++ b/src/main/java/backend/controller/ChallengeController.kt
@@ -94,7 +94,6 @@ class ChallengeController(private var challengeService: ChallengeService,
                 lastname = unregisteredSponsor.lastname!!,
                 company = unregisteredSponsor.company!!,
                 gender = unregisteredSponsor.gender!!,
-                url = unregisteredSponsor.url!!,
                 email = unregisteredSponsor.email,
                 address = unregisteredSponsor.address!!.toAddress()!!,
                 isHidden = unregisteredSponsor.isHidden)

--- a/src/main/java/backend/controller/SponsoringController.kt
+++ b/src/main/java/backend/controller/SponsoringController.kt
@@ -67,6 +67,7 @@ class SponsoringController(private var sponsoringService: SponsoringService,
                     view.sponsorIsHidden = true
                 }
                 view.unregisteredSponsor?.address = null
+                view.unregisteredSponsor?.email = null
             }
 
             sponsoring.sponsor.let {

--- a/src/main/java/backend/controller/SponsoringController.kt
+++ b/src/main/java/backend/controller/SponsoringController.kt
@@ -119,7 +119,6 @@ class SponsoringController(private var sponsoringService: SponsoringService,
                 lastname = sponsor.lastname!!,
                 company = sponsor.company!!,
                 gender = sponsor.gender!!,
-                url = sponsor.url!!,
                 address = sponsor.address!!.toAddress()!!,
                 email = sponsor.email,
                 isHidden = sponsor.isHidden)

--- a/src/main/java/backend/controller/SponsoringController.kt
+++ b/src/main/java/backend/controller/SponsoringController.kt
@@ -118,7 +118,6 @@ class SponsoringController(private var sponsoringService: SponsoringService,
                 firstname = sponsor.firstname!!,
                 lastname = sponsor.lastname!!,
                 company = sponsor.company!!,
-                gender = sponsor.gender!!,
                 address = sponsor.address!!.toAddress()!!,
                 email = sponsor.email,
                 isHidden = sponsor.isHidden)

--- a/src/main/java/backend/controller/UserController.kt
+++ b/src/main/java/backend/controller/UserController.kt
@@ -9,6 +9,7 @@ import backend.model.event.TeamService
 import backend.model.media.Media
 import backend.model.misc.Url
 import backend.model.user.*
+import backend.model.sponsoring.SupporterType
 import backend.model.removeBlockedBy
 import backend.model.removeBlocking
 import backend.services.ConfigurationService
@@ -32,6 +33,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
 import java.time.LocalDate
 import javax.validation.Valid
+
 
 @Api
 @RestController

--- a/src/main/java/backend/model/payment/SponsoringInvoice.kt
+++ b/src/main/java/backend/model/payment/SponsoringInvoice.kt
@@ -6,6 +6,7 @@ import backend.model.event.Team
 import backend.model.misc.EmailAddress
 import backend.model.sponsoring.ISponsor
 import backend.model.sponsoring.Sponsoring
+import backend.model.sponsoring.SupporterType
 import backend.model.sponsoring.UnregisteredSponsor
 import backend.model.user.Sponsor
 import backend.util.euroOf
@@ -27,9 +28,6 @@ class SponsoringInvoice : Invoice {
 
     @ManyToOne
     var event: Event? = null
-
-    @Enumerated(EnumType.STRING)
-    var type: SponsoringInvoiceType? = null
 
     @ManyToOne
     var unregisteredSponsor: UnregisteredSponsor? = null

--- a/src/main/java/backend/model/payment/SponsoringInvoice.kt
+++ b/src/main/java/backend/model/payment/SponsoringInvoice.kt
@@ -6,7 +6,6 @@ import backend.model.event.Team
 import backend.model.misc.EmailAddress
 import backend.model.sponsoring.ISponsor
 import backend.model.sponsoring.Sponsoring
-import backend.model.sponsoring.SupporterType
 import backend.model.sponsoring.UnregisteredSponsor
 import backend.model.user.Sponsor
 import backend.util.euroOf

--- a/src/main/java/backend/model/payment/SponsoringInvoiceType.kt
+++ b/src/main/java/backend/model/payment/SponsoringInvoiceType.kt
@@ -1,5 +1,0 @@
-package backend.model.payment
-
-enum class SponsoringInvoiceType {
-    Active, Passive, Donor
-}

--- a/src/main/java/backend/model/sponsoring/ISponsor.kt
+++ b/src/main/java/backend/model/sponsoring/ISponsor.kt
@@ -20,6 +20,8 @@ interface ISponsor {
 
     var url: Url?
 
+    var supporterType: SupporterType
+
     @Deprecated("Just a workaround")
     var registeredSponsor: Sponsor? // TODO: Fix this. Just a workaround!
 

--- a/src/main/java/backend/model/sponsoring/SupporterType.java
+++ b/src/main/java/backend/model/sponsoring/SupporterType.java
@@ -1,0 +1,8 @@
+package backend.model.sponsoring;
+
+public enum SupporterType {
+        NONE,
+        DONOR,
+        PASSIVE,
+        ACTIVE
+}

--- a/src/main/java/backend/model/sponsoring/UnregisteredSponsor.kt
+++ b/src/main/java/backend/model/sponsoring/UnregisteredSponsor.kt
@@ -5,6 +5,7 @@ import backend.model.challenges.Challenge
 import backend.model.misc.Url
 import backend.model.user.Address
 import backend.model.user.Sponsor
+import backend.model.sponsoring.SupporterType
 import javax.persistence.*
 
 @Entity
@@ -25,6 +26,9 @@ class UnregisteredSponsor : BasicEntity, ISponsor {
     override var company: String? = null
 
     lateinit var gender: String
+
+    @Enumerated(EnumType.STRING)
+    var supporterType: SupporterType = SupporterType.DONOR
 
     @Embedded
     @AttributeOverride(name = "value", column = Column(name = "url"))
@@ -54,7 +58,6 @@ class UnregisteredSponsor : BasicEntity, ISponsor {
                 lastname: String,
                 company: String,
                 gender: String,
-                url: String,
                 address: Address,
                 isHidden: Boolean = false,
                 email: String? = null) {
@@ -63,7 +66,6 @@ class UnregisteredSponsor : BasicEntity, ISponsor {
         this.lastname = lastname
         this.company = company
         this.gender = gender
-        this.url = Url(url)
         this.address = address
         this.isHidden = isHidden
         this.email = email

--- a/src/main/java/backend/model/sponsoring/UnregisteredSponsor.kt
+++ b/src/main/java/backend/model/sponsoring/UnregisteredSponsor.kt
@@ -5,7 +5,6 @@ import backend.model.challenges.Challenge
 import backend.model.misc.Url
 import backend.model.user.Address
 import backend.model.user.Sponsor
-import backend.model.sponsoring.SupporterType
 import javax.persistence.*
 
 @Entity
@@ -55,6 +54,8 @@ class UnregisteredSponsor : BasicEntity, ISponsor {
     constructor(firstname: String,
                 lastname: String,
                 company: String,
+                gender: String? = null,
+                url: String? = null,
                 address: Address,
                 isHidden: Boolean = false,
                 email: String? = null) {

--- a/src/main/java/backend/model/sponsoring/UnregisteredSponsor.kt
+++ b/src/main/java/backend/model/sponsoring/UnregisteredSponsor.kt
@@ -25,8 +25,6 @@ class UnregisteredSponsor : BasicEntity, ISponsor {
 
     override var company: String? = null
 
-    lateinit var gender: String
-
     @Enumerated(EnumType.STRING)
     override var supporterType: SupporterType = SupporterType.DONOR
 
@@ -57,7 +55,6 @@ class UnregisteredSponsor : BasicEntity, ISponsor {
     constructor(firstname: String,
                 lastname: String,
                 company: String,
-                gender: String,
                 address: Address,
                 isHidden: Boolean = false,
                 email: String? = null) {
@@ -65,7 +62,6 @@ class UnregisteredSponsor : BasicEntity, ISponsor {
         this.firstname = firstname
         this.lastname = lastname
         this.company = company
-        this.gender = gender
         this.address = address
         this.isHidden = isHidden
         this.email = email

--- a/src/main/java/backend/model/sponsoring/UnregisteredSponsor.kt
+++ b/src/main/java/backend/model/sponsoring/UnregisteredSponsor.kt
@@ -28,7 +28,7 @@ class UnregisteredSponsor : BasicEntity, ISponsor {
     lateinit var gender: String
 
     @Enumerated(EnumType.STRING)
-    var supporterType: SupporterType = SupporterType.DONOR
+    override var supporterType: SupporterType = SupporterType.DONOR
 
     @Embedded
     @AttributeOverride(name = "value", column = Column(name = "url"))

--- a/src/main/java/backend/model/user/Sponsor.kt
+++ b/src/main/java/backend/model/user/Sponsor.kt
@@ -7,6 +7,7 @@ import backend.model.media.Media
 import backend.model.misc.Url
 import backend.model.sponsoring.ISponsor
 import backend.model.sponsoring.Sponsoring
+import backend.model.sponsoring.SupporterType
 import backend.model.sponsoring.UnregisteredSponsor
 import javax.persistence.*
 import javax.persistence.CascadeType.ALL
@@ -75,11 +76,4 @@ class Sponsor : UserRole, ISponsor {
         this.challenges.forEach(Challenge::removeSponsor)
         this.sponsorings.clear()
     }
-}
-
-enum class SupporterType {
-    NONE,
-    DONOR,
-    PASSIVE,
-    ACTIVE
 }

--- a/src/main/java/backend/model/user/Sponsor.kt
+++ b/src/main/java/backend/model/user/Sponsor.kt
@@ -25,7 +25,7 @@ class Sponsor : UserRole, ISponsor {
         set(value) {}
 
     @Enumerated(EnumType.STRING)
-    var supporterType: SupporterType = SupporterType.NONE
+    override var supporterType: SupporterType = SupporterType.NONE
 
     override var company: String? = null
 

--- a/src/main/java/backend/view/UnregisteredSponsorView.kt
+++ b/src/main/java/backend/view/UnregisteredSponsorView.kt
@@ -22,9 +22,6 @@ class UnregisteredSponsorView() {
     @SafeHtml(whitelistType = NONE)
     var url: String? = null
 
-    @NotNull
-    @SafeHtml(whitelistType = NONE)
-    var gender: String? = null
 
     @NotNull
     @SafeHtml(whitelistType = NONE)
@@ -44,7 +41,6 @@ class UnregisteredSponsorView() {
         this.address = UserView.AddressView(unregisteredSponsor.address)
         this.company = unregisteredSponsor.company
         this.url = unregisteredSponsor.url.toString()
-        this.gender = unregisteredSponsor.gender
         this.firstname = unregisteredSponsor.firstname
         this.lastname = unregisteredSponsor.lastname
         this.isHidden = unregisteredSponsor.isHidden

--- a/src/main/java/backend/view/sponsoring/SponsoringInvoiceView.kt
+++ b/src/main/java/backend/view/sponsoring/SponsoringInvoiceView.kt
@@ -36,7 +36,7 @@ class DetailedSponsoringInvoiceView : SponsoringInvoiceView {
     constructor(invoice: SponsoringInvoice) : super(invoice) {
         this.challenges = invoice.challenges.map { ChallengeView(it) }
         this.sponsorings = invoice.sponsorings.map { SponsoringView(it) }
-        this.type = invoice.type?.toString()
+        this.type = invoice.sponsor.supporterType.toString()
         this.contactEmails = invoice.getContactEmails().map { email -> email.toString() }
     }
 }

--- a/src/main/java/backend/view/user/UserView.kt
+++ b/src/main/java/backend/view/user/UserView.kt
@@ -1,6 +1,7 @@
 package backend.view.user
 
 import backend.model.user.*
+import backend.model.sponsoring.SupporterType
 import backend.model.removeBlockedBy
 import backend.model.removeBlocking
 import backend.view.MediaView

--- a/src/main/resources/db/migration/V201805121512__add_unregistered_supporter_type.sql
+++ b/src/main/resources/db/migration/V201805121512__add_unregistered_supporter_type.sql
@@ -1,0 +1,2 @@
+ALTER TABLE unregistered_sponsor
+  ADD supporter_type VARCHAR(31)

--- a/src/test/java/backend/controller/ChallengeControllerTest.kt
+++ b/src/test/java/backend/controller/ChallengeControllerTest.kt
@@ -73,7 +73,6 @@ class ChallengeControllerTest : IntegrationTest() {
                         "lastname" to "Meier",
                         "company" to "privat",
                         "url" to "",
-                        "gender" to "male",
                         "isHidden" to "false",
                         "email" to "sponsor@example.com",
                         "address" to mapOf(
@@ -107,7 +106,6 @@ class ChallengeControllerTest : IntegrationTest() {
                 .andExpect(jsonPath("$.unregisteredSponsor.lastname").exists())
                 .andExpect(jsonPath("$.unregisteredSponsor.company").exists())
                 .andExpect(jsonPath("$.unregisteredSponsor.url").exists())
-                .andExpect(jsonPath("$.unregisteredSponsor.gender").exists())
                 .andExpect(jsonPath("$.unregisteredSponsor.hidden").exists())
                 .andExpect(jsonPath("$.unregisteredSponsor.address").exists())
     }
@@ -259,7 +257,6 @@ class ChallengeControllerTest : IntegrationTest() {
                 .andExpect(jsonPath("$.[1].unregisteredSponsor.lastname").exists())
                 .andExpect(jsonPath("$.[1].unregisteredSponsor.company").exists())
                 .andExpect(jsonPath("$.[1].unregisteredSponsor.url").exists())
-                .andExpect(jsonPath("$.[1].unregisteredSponsor.gender").exists())
                 .andExpect(jsonPath("$.[1].unregisteredSponsor.address").doesNotExist())
                 .andExpect(jsonPath("$.[1].team").exists())
                 .andExpect(jsonPath("$.[1].teamId").exists())

--- a/src/test/java/backend/controller/SponsoringControllerTest.kt
+++ b/src/test/java/backend/controller/SponsoringControllerTest.kt
@@ -269,8 +269,6 @@ class SponsoringControllerTest : IntegrationTest() {
                 .andExpect(jsonPath("$.userId").doesNotExist())
                 .andExpect(jsonPath("$.unregisteredSponsor.firstname").value("Florian"))
                 .andExpect(jsonPath("$.unregisteredSponsor.lastname").value("Schmidt"))
-                .andExpect(jsonPath("$.unregisteredSponsor.url").value("www.florianschmidt.me"))
-                .andExpect(jsonPath("$.unregisteredSponsor.gender").value("male"))
                 .andExpect(jsonPath("$.unregisteredSponsor.hidden").value(false))
                 .andExpect(jsonPath("$.unregisteredSponsor.company").value("awesome AG"))
                 .andExpect(jsonPath("$.unregisteredSponsor.email").value("sponsor@example.com"))


### PR DESCRIPTION
[Corresponding PR in Frontend Repo](https://github.com/BreakOutEvent/breakout-frontend/pull/315)
- Add supporter type field to unregistered sponsor and set it to DONOR
- Teams only can view address and email information in challenge and sponsoring overview