### PR TITLE
Make sponsoring(challenges & km-sponsoring) easier

### DIFF
--- a/src/main/java/backend/controller/ChallengeController.kt
+++ b/src/main/java/backend/controller/ChallengeController.kt
@@ -88,7 +88,8 @@ class ChallengeController(private var challengeService: ChallengeService,
     }
 
     private fun challengeUnregisteredSponsor(body: ChallengeView, team: Team, amount: Money, description: String): ChallengeView {
-        val unregisteredSponsor = body.unregisteredSponsor ?: throw BadRequestException("Missing data for unregistered sponsor")
+        val unregisteredSponsor = body.unregisteredSponsor
+                ?: throw BadRequestException("Missing data for unregistered sponsor")
 
         val sponsor = UnregisteredSponsor(
                 firstname = unregisteredSponsor.firstname!!,
@@ -112,13 +113,15 @@ class ChallengeController(private var challengeService: ChallengeService,
     fun changeStatus(@PathVariable challengeId: Long,
                      @Valid @RequestBody body: ChallengeStatusView): ChallengeView {
 
-        val challenge = challengeService.findOne(challengeId) ?: throw NotFoundException("No challenge with id $challengeId found")
+        val challenge = challengeService.findOne(challengeId)
+                ?: throw NotFoundException("No challenge with id $challengeId found")
         return when (body.status!!.toLowerCase()) {
             "accepted" -> challengeService.accept(challenge)
             "rejected" -> challengeService.reject(challenge)
             "withdrawn" -> challengeService.withdraw(challenge)
             "with_proof" -> {
-                val proof = postingService.getByID(body.postingId!!) ?: throw NotFoundException("No posting with id ${body.postingId} found")
+                val proof = postingService.getByID(body.postingId!!)
+                        ?: throw NotFoundException("No posting with id ${body.postingId} found")
                 challengeService.addProof(challenge, proof)
             }
             else -> throw BadRequestException("Unknown status for challenge ${body.status}")
@@ -181,6 +184,7 @@ class ChallengeController(private var challengeService: ChallengeService,
 
             val sponsor = when (it.sponsor.isHidden) {
                 true -> SponsorTeamProfileView(
+                        sponsorId = null,
                         firstname = "",
                         lastname = "",
                         company = null,
@@ -188,6 +192,7 @@ class ChallengeController(private var challengeService: ChallengeService,
                         url = null,
                         logoUrl = null)
                 false -> SponsorTeamProfileView(
+                        sponsorId = it.sponsor.registeredSponsor?.id,
                         firstname = it.sponsor.firstname ?: "",
                         lastname = it.sponsor.lastname ?: "",
                         company = it.sponsor.company,

--- a/src/main/java/backend/controller/ChallengeController.kt
+++ b/src/main/java/backend/controller/ChallengeController.kt
@@ -82,7 +82,7 @@ class ChallengeController(private var challengeService: ChallengeService,
     }
 
     private fun challengeWithRegisteredSponsor(user: User, team: Team, amount: Money, description: String): ChallengeView {
-        val sponsor = user.getRole(Sponsor::class) ?: throw UnauthorizedException("User is no sponsor")
+        val sponsor = user.getRole(Sponsor::class) ?: user.addRole(Sponsor::class)
         val challenge = challengeService.proposeChallenge(sponsor, team, amount, description)
         return ChallengeView(challenge)
     }

--- a/src/main/java/backend/controller/SponsoringController.kt
+++ b/src/main/java/backend/controller/SponsoringController.kt
@@ -166,6 +166,7 @@ class SponsoringController(private var sponsoringService: SponsoringService,
         return sponsoringService.findByTeamId(teamId).map {
             val sponsor = when (it.sponsor.isHidden) {
                 true -> SponsorTeamProfileView(
+                        sponsorId = null,
                         firstname = "",
                         lastname = "",
                         company = null,
@@ -173,6 +174,7 @@ class SponsoringController(private var sponsoringService: SponsoringService,
                         url = null,
                         logoUrl = null)
                 false -> SponsorTeamProfileView(
+                        sponsorId = it.sponsor.registeredSponsor?.id,
                         firstname = it.sponsor.firstname ?: "",
                         lastname = it.sponsor.lastname ?: "",
                         company = it.sponsor.company,

--- a/src/main/java/backend/controller/UserController.kt
+++ b/src/main/java/backend/controller/UserController.kt
@@ -282,10 +282,11 @@ class UserController(private val userService: UserService,
         sponsor.address = sponsorView.address?.toAddress() ?: sponsor.address
         sponsor.isHidden = sponsorView.isHidden ?: sponsor.isHidden
         sponsor.company = sponsorView.company ?: sponsor.company
-        sponsor.logo = sponsorView.logo?.let(::Media) ?: sponsor.logo
+        sponsor.logo = sponsorView.logo?.let(::Media) ?: null
 
         val urlString = sponsorView.url
         if (urlString != null) sponsor.url = Url(urlString)
+        else sponsor.url = null
 
         return this
     }

--- a/src/main/java/backend/model/sponsoring/ISponsor.kt
+++ b/src/main/java/backend/model/sponsoring/ISponsor.kt
@@ -15,7 +15,7 @@ interface ISponsor {
 
     var company: String?
 
-    var address: Address
+    var address: Address?
 
     var isHidden: Boolean
 

--- a/src/main/java/backend/model/sponsoring/Sponsoring.kt
+++ b/src/main/java/backend/model/sponsoring/Sponsoring.kt
@@ -133,6 +133,7 @@ class Sponsoring : BasicEntity, Billable {
                 PROPOSED to WITHDRAWN,
                 REJECTED to WITHDRAWN,
                 ACCEPTED to WITHDRAWN,
+                ACCEPTED to REJECTED,
                 ACCEPTED to PAYED)
 
         if (!transitions.contains(from to to)) {

--- a/src/main/java/backend/model/sponsoring/Sponsoring.kt
+++ b/src/main/java/backend/model/sponsoring/Sponsoring.kt
@@ -24,7 +24,7 @@ class Sponsoring : BasicEntity, Billable {
     @OneToOne(cascade = [(CascadeType.ALL)], orphanRemoval = true)
     var contract: Media? = null
 
-    var status: SponsoringStatus = PROPOSED
+    var status: SponsoringStatus = ACCEPTED
         private set (value) {
             checkTransition(from = field, to = value)
             field = value

--- a/src/main/java/backend/model/sponsoring/UnregisteredSponsor.kt
+++ b/src/main/java/backend/model/sponsoring/UnregisteredSponsor.kt
@@ -33,7 +33,7 @@ class UnregisteredSponsor : BasicEntity, ISponsor {
     override var url: Url? = null
 
     @Embedded
-    override lateinit var address: Address
+    override var address: Address? = null
 
     @OneToMany(mappedBy = "unregisteredSponsor")
     override var sponsorings: MutableList<Sponsoring> = mutableListOf()

--- a/src/main/java/backend/model/user/Sponsor.kt
+++ b/src/main/java/backend/model/user/Sponsor.kt
@@ -42,7 +42,7 @@ class Sponsor : UserRole, ISponsor {
     override var url: Url? = null
 
     @Embedded
-    override lateinit var address: Address
+    override var address: Address? = null
 
     override var isHidden: Boolean = false
 

--- a/src/main/java/backend/model/user/UserServiceImpl.kt
+++ b/src/main/java/backend/model/user/UserServiceImpl.kt
@@ -59,9 +59,7 @@ class UserServiceImpl @Autowired constructor(private val userRepository: UserRep
     }
 
     private fun sendActivationEmail(token: String, user: User) {
-        // TODO: Fix activation
-        // See https://github.com/BreakOutEvent/breakout-backend/issues/221
-        // mailService.sendUserHasRegisteredEmail(token, user)
+        mailService.sendUserHasRegisteredEmail(token, user)
     }
 
     override fun save(user: User): User {

--- a/src/main/java/backend/view/SponsorTeamProfileView.kt
+++ b/src/main/java/backend/view/SponsorTeamProfileView.kt
@@ -5,6 +5,7 @@ import backend.model.misc.Url
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
 
 class SponsorTeamProfileView(
+        var sponsorId: Long?,
         val firstname: String,
         val lastname: String,
         val company: String?,

--- a/src/main/java/backend/view/user/UserView.kt
+++ b/src/main/java/backend/view/user/UserView.kt
@@ -61,7 +61,7 @@ class UserView() {
         this.id = user.account.id
         this.isBlocked = user.isBlocked
         this.participant = if (user.hasRole(Participant::class)) ParticipantViewModel(user) else null
-        this.sponsor = if (user.hasRole(Sponsor::class)) SponsorView(user) else null
+        this.sponsor = SponsorView(user)
         this.profilePic = user.profilePic?.let(::MediaView)
         this.roles = user.account.getAuthorities().map { it.authority }
 
@@ -154,9 +154,9 @@ class UserView() {
                 else -> null
             }
             this.company = sponsor?.company
-            this.url = sponsor?.url.toString()
-            this.address = AddressView(sponsor?.address)
+            this.url = sponsor?.url?.toString()
             this.logo = sponsor?.logo?.let(::MediaView)
+            this.address = sponsor?.address?.let(::AddressView)
             this.isHidden = sponsor?.isHidden
         }
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,7 +18,7 @@ org.breakout.mailer.url=http://localhost:3000
 org.breakout.mailer.xauthtoken=123456789
 
 # These settings will be used for creating valid activation links
-org.breakout.api.host=http://localhost:8082
+org.breakout.api.host=http://localhost:3000
 
 # Notifications
 org.breakout.api.notifications.url=https://onesignal.com

--- a/src/main/resources/db/migration/V201806012220__add_emoji_support_to_posting.sql
+++ b/src/main/resources/db/migration/V201806012220__add_emoji_support_to_posting.sql
@@ -120,12 +120,12 @@ alter table posting_media convert to character set utf8mb4 collate utf8mb4_unico
 
 alter table postinglike convert to character set utf8mb4 collate utf8mb4_unicode_ci;
 
-alter table schema_version convert to character set utf8mb4 collate utf8mb4_unicode_ci;
-ALTER TABLE `schema_version` CHANGE `version` `version` VARCHAR(50)  CHARACTER SET utf8mb4  COLLATE utf8mb4_unicode_ci  NULL  DEFAULT NULL;
-ALTER TABLE `schema_version` CHANGE `description` `description` VARCHAR(200)  CHARACTER SET utf8mb4  COLLATE utf8mb4_unicode_ci  NOT NULL  DEFAULT '';
-ALTER TABLE `schema_version` CHANGE `type` `type` VARCHAR(20)  CHARACTER SET utf8mb4  COLLATE utf8mb4_unicode_ci  NOT NULL  DEFAULT '';
-ALTER TABLE `schema_version` CHANGE `script` `script` VARCHAR(1000)  CHARACTER SET utf8mb4  COLLATE utf8mb4_unicode_ci  NOT NULL  DEFAULT '';
-ALTER TABLE `schema_version` CHANGE `installed_by` `installed_by` VARCHAR(100)  CHARACTER SET utf8mb4  COLLATE utf8mb4_unicode_ci  NOT NULL  DEFAULT '';
+-- alter table schema_version convert to character set utf8mb4 collate utf8mb4_unicode_ci;
+-- ALTER TABLE `schema_version` CHANGE `version` `version` VARCHAR(50)  CHARACTER SET utf8mb4  COLLATE utf8mb4_unicode_ci  NULL  DEFAULT NULL;
+-- ALTER TABLE `schema_version` CHANGE `description` `description` VARCHAR(200)  CHARACTER SET utf8mb4  COLLATE utf8mb4_unicode_ci  NOT NULL  DEFAULT '';
+-- ALTER TABLE `schema_version` CHANGE `type` `type` VARCHAR(20)  CHARACTER SET utf8mb4  COLLATE utf8mb4_unicode_ci  NOT NULL  DEFAULT '';
+-- ALTER TABLE `schema_version` CHANGE `script` `script` VARCHAR(1000)  CHARACTER SET utf8mb4  COLLATE utf8mb4_unicode_ci  NOT NULL  DEFAULT '';
+-- ALTER TABLE `schema_version` CHANGE `installed_by` `installed_by` VARCHAR(100)  CHARACTER SET utf8mb4  COLLATE utf8mb4_unicode_ci  NOT NULL  DEFAULT '';
 
 alter table sponsoring convert to character set utf8mb4 collate utf8mb4_unicode_ci;
 ALTER TABLE `sponsoring` CHANGE `amount_per_km` `amount_per_km` VARCHAR(255)  CHARACTER SET utf8mb4  COLLATE utf8mb4_unicode_ci  NULL  DEFAULT NULL;

--- a/src/main/resources/db/migration/V201806012220__add_emoji_support_to_posting.sql
+++ b/src/main/resources/db/migration/V201806012220__add_emoji_support_to_posting.sql
@@ -120,12 +120,12 @@ alter table posting_media convert to character set utf8mb4 collate utf8mb4_unico
 
 alter table postinglike convert to character set utf8mb4 collate utf8mb4_unicode_ci;
 
--- alter table schema_version convert to character set utf8mb4 collate utf8mb4_unicode_ci;
--- ALTER TABLE `schema_version` CHANGE `version` `version` VARCHAR(50)  CHARACTER SET utf8mb4  COLLATE utf8mb4_unicode_ci  NULL  DEFAULT NULL;
--- ALTER TABLE `schema_version` CHANGE `description` `description` VARCHAR(200)  CHARACTER SET utf8mb4  COLLATE utf8mb4_unicode_ci  NOT NULL  DEFAULT '';
--- ALTER TABLE `schema_version` CHANGE `type` `type` VARCHAR(20)  CHARACTER SET utf8mb4  COLLATE utf8mb4_unicode_ci  NOT NULL  DEFAULT '';
--- ALTER TABLE `schema_version` CHANGE `script` `script` VARCHAR(1000)  CHARACTER SET utf8mb4  COLLATE utf8mb4_unicode_ci  NOT NULL  DEFAULT '';
--- ALTER TABLE `schema_version` CHANGE `installed_by` `installed_by` VARCHAR(100)  CHARACTER SET utf8mb4  COLLATE utf8mb4_unicode_ci  NOT NULL  DEFAULT '';
+alter table schema_version convert to character set utf8mb4 collate utf8mb4_unicode_ci;
+ALTER TABLE `schema_version` CHANGE `version` `version` VARCHAR(50)  CHARACTER SET utf8mb4  COLLATE utf8mb4_unicode_ci  NULL  DEFAULT NULL;
+ALTER TABLE `schema_version` CHANGE `description` `description` VARCHAR(200)  CHARACTER SET utf8mb4  COLLATE utf8mb4_unicode_ci  NOT NULL  DEFAULT '';
+ALTER TABLE `schema_version` CHANGE `type` `type` VARCHAR(20)  CHARACTER SET utf8mb4  COLLATE utf8mb4_unicode_ci  NOT NULL  DEFAULT '';
+ALTER TABLE `schema_version` CHANGE `script` `script` VARCHAR(1000)  CHARACTER SET utf8mb4  COLLATE utf8mb4_unicode_ci  NOT NULL  DEFAULT '';
+ALTER TABLE `schema_version` CHANGE `installed_by` `installed_by` VARCHAR(100)  CHARACTER SET utf8mb4  COLLATE utf8mb4_unicode_ci  NOT NULL  DEFAULT '';
 
 alter table sponsoring convert to character set utf8mb4 collate utf8mb4_unicode_ci;
 ALTER TABLE `sponsoring` CHANGE `amount_per_km` `amount_per_km` VARCHAR(255)  CHARACTER SET utf8mb4  COLLATE utf8mb4_unicode_ci  NULL  DEFAULT NULL;

--- a/src/test/java/backend/controller/SponsoringControllerTest.kt
+++ b/src/test/java/backend/controller/SponsoringControllerTest.kt
@@ -196,7 +196,7 @@ class SponsoringControllerTest : IntegrationTest() {
                 .andExpect(jsonPath("$.team").exists())
                 .andExpect(jsonPath("$.sponsorId").exists())
                 .andExpect(jsonPath("$.userId").exists())
-                .andExpect(jsonPath("$.status").value("PROPOSED"))
+                .andExpect(jsonPath("$.status").value("ACCEPTED"))
                 .andExpect(jsonPath("$.unregisteredSponsor").doesNotExist())
     }
 
@@ -222,7 +222,7 @@ class SponsoringControllerTest : IntegrationTest() {
                 .andExpect(jsonPath("$.team").exists())
                 .andExpect(jsonPath("$.sponsorId").exists())
                 .andExpect(jsonPath("$.userId").exists())
-                .andExpect(jsonPath("$.status").value("PROPOSED"))
+                .andExpect(jsonPath("$.status").value("ACCEPTED"))
                 .andExpect(jsonPath("$.unregisteredSponsor").doesNotExist())
     }
 

--- a/src/test/java/backend/model/sponsoring/SponsoringServiceImplTest.kt
+++ b/src/test/java/backend/model/sponsoring/SponsoringServiceImplTest.kt
@@ -67,7 +67,7 @@ class SponsoringServiceImplTest : IntegrationTest() {
         assertFails { sponsoringService.acceptSponsoring(sponsoring) }
 
         val found = sponsoringRepository.findOne(sponsoring.id)
-        assertEquals(PROPOSED, found.status)
+        assertEquals(ACCEPTED, found.status)
 
     }
 
@@ -100,7 +100,7 @@ class SponsoringServiceImplTest : IntegrationTest() {
         assertFails { sponsoringService.rejectSponsoring(sponsoring) }
 
         val found = sponsoringRepository.findOne(sponsoring.id)
-        assertEquals(PROPOSED, found.status)
+        assertEquals(ACCEPTED, found.status)
     }
 
     @Test
@@ -175,7 +175,7 @@ class SponsoringServiceImplTest : IntegrationTest() {
         assertFails { sponsoringService.withdrawSponsoring(sponsoring) }
 
         val found = sponsoringRepository.findOne(sponsoring.id)
-        assertEquals(PROPOSED, found.status)
+        assertEquals(ACCEPTED, found.status)
     }
 
 }

--- a/src/test/java/backend/model/sponsoring/SponsoringTest.kt
+++ b/src/test/java/backend/model/sponsoring/SponsoringTest.kt
@@ -63,7 +63,7 @@ class SponsoringTest {
         val sponsor = PowerMockito.mock(Sponsor::class.java)
         val sponsoring = Sponsoring(sponsor, team, amountPerKm, limit)
 
-        assertEquals(PROPOSED, sponsoring.status)
+        assertEquals(ACCEPTED, sponsoring.status)
         sponsoring.accept()
         assertEquals(ACCEPTED, sponsoring.status)
     }
@@ -76,7 +76,7 @@ class SponsoringTest {
         val sponsor = PowerMockito.mock(Sponsor::class.java)
         val sponsoring = Sponsoring(sponsor, team, amountPerKm, limit)
 
-        assertEquals(PROPOSED, sponsoring.status)
+        assertEquals(ACCEPTED, sponsoring.status)
         sponsoring.accept()
         assertEquals(ACCEPTED, sponsoring.status)
     }
@@ -89,7 +89,7 @@ class SponsoringTest {
         val sponsor = PowerMockito.mock(Sponsor::class.java)
         val sponsoring = Sponsoring(sponsor, team, amountPerKm, limit)
 
-        assertEquals(PROPOSED, sponsoring.status)
+        assertEquals(ACCEPTED, sponsoring.status)
         sponsoring.reject()
         assertEquals(REJECTED, sponsoring.status)
     }


### PR DESCRIPTION
This PR makes it possible to create a sponsoring directly on a team page.

Additionally it sets new challenges and sponsorings directly to ACCEPTED. They can be rejected by the team afterwards, if they don't want to have it.

Confirmation emails are sent but not necessary to be received.