### PR TITLE
Bugfix/teamoverview

### DIFF
--- a/src/main/java/backend/Teamoverview/ContactWithHeadquarters.kt
+++ b/src/main/java/backend/Teamoverview/ContactWithHeadquarters.kt
@@ -1,0 +1,28 @@
+package backend.Teamoverview
+
+import backend.model.BasicEntity
+import backend.model.event.Team
+import backend.model.user.UserAccount
+import javax.persistence.*
+
+@Entity
+class ContactWithHeadquarters : BasicEntity {
+
+    @Column(columnDefinition = "TEXT")
+    var comment: String? = null
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    var admin: UserAccount? = null
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    var team: Team? = null
+
+    private constructor() : super()
+
+    constructor(team: Team, comment: String, admin: UserAccount) {
+        this.team = team
+        this.comment = comment
+        this.admin = admin
+    }
+
+}

--- a/src/main/java/backend/Teamoverview/ContactWithHeadquarters.kt
+++ b/src/main/java/backend/Teamoverview/ContactWithHeadquarters.kt
@@ -1,4 +1,4 @@
-package backend.Teamoverview
+package backend.teamoverview
 
 import backend.model.BasicEntity
 import backend.model.event.Team

--- a/src/main/java/backend/Teamoverview/ContactWithHeadquarters.kt
+++ b/src/main/java/backend/Teamoverview/ContactWithHeadquarters.kt
@@ -8,19 +8,32 @@ import javax.persistence.*
 @Entity
 class ContactWithHeadquarters : BasicEntity {
 
+    enum class Reason {
+        TECHNICAL_PROBLEM,
+        FIVE_HOUR_NOTIFICATION,
+        NEW_TRANSPORT,
+        FINISHED,
+        SICKNESS,
+        EMERGENCY,
+        OTHER
+    }
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    var team: Team? = null
+
+    var reason: Reason? = null
+
     @Column(columnDefinition = "TEXT")
     var comment: String? = null
 
     @ManyToOne(fetch = FetchType.LAZY)
     var admin: UserAccount? = null
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    var team: Team? = null
-
     private constructor() : super()
 
-    constructor(team: Team, comment: String, admin: UserAccount) {
+    constructor(team: Team, reason: Reason, comment: String?, admin: UserAccount) {
         this.team = team
+        this.reason = reason
         this.comment = comment
         this.admin = admin
     }

--- a/src/main/java/backend/Teamoverview/ContactWithHeadquartersRepository.kt
+++ b/src/main/java/backend/Teamoverview/ContactWithHeadquartersRepository.kt
@@ -1,0 +1,19 @@
+package backend.Teamoverview
+
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.CrudRepository
+import org.springframework.data.repository.query.Param
+
+interface ContactWithHeadquartersRepository : CrudRepository<ContactWithHeadquarters, Long> {
+
+    fun findAllByTeamId(teamId: Long): Iterable<ContactWithHeadquarters>
+
+    @Query("""
+        select *
+        from contact_with_headquarters
+        where team_id = :id
+        order by id desc
+        limit 1
+    """, nativeQuery = true)
+    fun findLastContactByTeamId(@Param("id") id: Long): ContactWithHeadquarters?
+}

--- a/src/main/java/backend/Teamoverview/ContactWithHeadquartersRepository.kt
+++ b/src/main/java/backend/Teamoverview/ContactWithHeadquartersRepository.kt
@@ -1,4 +1,4 @@
-package backend.Teamoverview
+package backend.teamoverview
 
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.CrudRepository

--- a/src/main/java/backend/Teamoverview/TeamOverview.kt
+++ b/src/main/java/backend/Teamoverview/TeamOverview.kt
@@ -8,6 +8,13 @@ import java.time.ZoneId
 
 interface TeamOverview {
 
+    interface Event {
+        val id: Long
+
+        @Value("#{target.title}")
+        fun getName(): String
+    }
+
     interface Participant {
         val id: Long
         val firstname: String?
@@ -52,17 +59,13 @@ interface TeamOverview {
         fun getTimestamp(): Long
     }
 
+    val event: Event
+    
     @Value("#{target.id}")
     fun getTeamId(): Long
 
     @Value("#{target.name}")
     fun getTeamName(): String
-
-    @Value("#{target.event.id}")
-    fun getEventId(): Long
-
-    @Value("#{target.event.title}")
-    fun getEventTitle(): String
 
     @Value("#{target.members}")
     fun getMembers(): List<Participant>

--- a/src/main/java/backend/Teamoverview/TeamOverview.kt
+++ b/src/main/java/backend/Teamoverview/TeamOverview.kt
@@ -5,7 +5,6 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import java.time.LocalDateTime
 import java.time.ZoneId
-import java.time.ZoneOffset
 
 interface TeamOverview {
 

--- a/src/main/java/backend/Teamoverview/TeamOverview.kt
+++ b/src/main/java/backend/Teamoverview/TeamOverview.kt
@@ -67,6 +67,9 @@ interface TeamOverview {
     @Value("#{target.name}")
     fun getTeamName(): String
 
+    @Value("#{target.asleep}")
+    fun getAsleep(): Boolean
+
     @Value("#{target.members}")
     fun getMembers(): List<Participant>
 

--- a/src/main/java/backend/Teamoverview/TeamOverview.kt
+++ b/src/main/java/backend/Teamoverview/TeamOverview.kt
@@ -1,179 +1,87 @@
 package backend.Teamoverview
 
-import backend.model.BasicEntity
-import backend.model.event.Event
-import backend.model.event.Team
-import backend.model.location.Location
-import com.fasterxml.jackson.core.JsonGenerator
-import com.fasterxml.jackson.databind.SerializerProvider
-import com.fasterxml.jackson.databind.annotation.JsonSerialize
-import com.fasterxml.jackson.databind.ser.std.StdSerializer
+import backend.model.misc.Coord
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
 import java.time.LocalDateTime
 import java.time.ZoneId
-import javax.persistence.*
+import java.time.ZoneOffset
 
-@Entity
-class TeamOverview : BasicEntity {
+interface TeamOverview {
 
-    private constructor() : super()
+    interface Participant {
+        val id: Long
+        val firstname: String?
+        val lastname: String?
 
-    constructor(team: Team, event: Event) {
-        setOrUpdateValues(event, team)
+        @Value("#{target.emergencynumber}")
+        fun getEmergencyPhone(): String
+
+        @Value("#{target.phonenumber}")
+        fun getContactPhone(): String
     }
 
-    fun setOrUpdateValues(event: Event, team: Team) {
-        this.teamId = team.id!!
-        this.teamName = team.name
-        this.event = Event(event.id, event.title)
-        this.members = team.members.map {
-            TeamMember(it.id, it.firstname, it.lastname, it.emergencynumber, it.phonenumber)
+    interface Location {
+        val id: Long
+        val coord: Coord
+        val locationData: Map<String, String>
+
+        @Value("#{@dateTimeBean.formatDateTime(target.date)}")
+        fun getTimestamp(): Long
+    }
+
+    interface Posting {
+        val id: Long
+
+        @Value("#{@dateTimeBean.formatDateTime(target.date)}")
+        fun getTimestamp(): Long
+    }
+
+    interface Contact {
+
+        interface Admin {
+            val id: Long
+            val firstname: String?
+            val lastname: String?
         }
+
+        val id: Long
+        val admin: Admin
+        val comment: String?
+
+        @Value("#{@dateTimeBean.formatDateTime(target.createdAt)}")
+        fun getTimestamp(): Long
     }
 
-    var teamId: Long = -1
+    @Value("#{target.id}")
+    fun getTeamId(): Long
 
-    lateinit var teamName: String
+    @Value("#{target.name}")
+    fun getTeamName(): String
 
-    @Embedded
-    var event: backend.Teamoverview.Event? = null
+    @Value("#{target.event.id}")
+    fun getEventId(): Long
 
-    @ElementCollection(fetch = FetchType.EAGER)
-    var members: List<TeamMember> = listOf()
+    @Value("#{target.event.title}")
+    fun getEventTitle(): String
 
-    @Embedded
-    @AttributeOverrides(
-            AttributeOverride(name = "latitude", column = Column(nullable = true)),
-            AttributeOverride(name = "longitude", column = Column(nullable = true))
-    )
-    var lastLocation: LastLocation? = null
+    @Value("#{target.members}")
+    fun getMembers(): List<Participant>
 
-    @Embedded
-    var lastPosting: LastPosting? = null
+    @Value("#{@locationRepository.findLastLocationByTeamId(target.id)}")
+    fun getLastLocation(): Location?
 
-    @Embedded
-    var lastContactWithHeadquarters: LastContactWithHeadquarters? = null
+    @Value("#{@postingRepository.findLastPostingByTeamId(target.id)}")
+    fun getLastPosting(): Posting?
 
-    fun setLastContactWithHeadquarters(comment: String, timestamp: LocalDateTime) {
-        val lastContact = LastContactWithHeadquarters(timestamp, comment)
-        this.lastContactWithHeadquarters = lastContact
-    }
-
+    @Value("#{@contactWithHeadquartersRepository.findLastContactByTeamId(target.id)}")
+    fun getLastContactWithHeadquarters(): Contact?
 }
 
-@Embeddable
-class Event() {
-
-    @Column(name = "event_id")
-    var id: Long? = null
-    var name: String? = null
-
-    constructor(id: Long?, name: String?) : this() {
-        this.id = id
-        this.name = name
-    }
-}
-
-@Embeddable
-class TeamMember {
-
-    constructor()
-
-    var id: Long? = null
-    var firstname: String? = null
-    var lastname: String? = null
-    var emergencyPhone: String? = null
-    var contactPhone: String? = null
-
-    constructor(id: Long?, firstname: String?, lastname: String?, emergencyPhone: String?, contactPhone: String?) {
-        this.id = id
-        this.firstname = firstname
-        this.lastname = lastname
-        this.emergencyPhone = emergencyPhone
-        this.contactPhone = contactPhone
-    }
-}
-
-@Embeddable
-class LastLocation() {
-
-    @Embedded
-    var coord: Coord? = null
-
-    @Column(name = "location_id")
-    var id: Long? = null
-
-    @Column(name = "location_timestamp")
-    @JsonSerialize(using = TimestampSerializer::class)
-    var timestamp: LocalDateTime? = null
-
-    @ElementCollection(fetch = FetchType.EAGER)
-    @MapKeyColumn(name = "last_location_data_key")
-    @Column(name = "last_location_data_value")
-    var locationData: MutableMap<String, String> = mutableMapOf()
-
-    constructor(location: Location) : this() {
-        this.coord = Coord(location.coord.latitude, location.coord.longitude)
-        this.id = location.id
-        this.locationData = location.locationData.toMutableMap()
-        this.timestamp = location.date
-
-    }
-}
-
-@Embeddable
-class Coord() {
-
-    var latitude: Double? = null
-    var longitude: Double? = null
-
-    constructor(latitude: Double, longitude: Double) : this() {
-        this.latitude = latitude
-        this.longitude = longitude
-    }
-}
-
-
-@Embeddable
-class LastPosting() {
-    @Column(name = "posting_id")
-    var id: Long? = null
-
-    @Column(name = "posting_timestamp")
-    @JsonSerialize(using = TimestampSerializer::class)
-    var timestamp: LocalDateTime? = null
-
-    constructor(id: Long?, timestamp: LocalDateTime) : this() {
-        this.id = id
-        this.timestamp = timestamp
-    }
-}
-
-@Embeddable
-class LastContactWithHeadquarters() {
-
-    @JsonSerialize(using = TimestampSerializer::class)
-    var timestamp: LocalDateTime? = null
-
-    @Column(columnDefinition = "TEXT")
-    var comment: String? = null
-
-    constructor(timestamp: LocalDateTime, comment: String) : this() {
-        this.timestamp = timestamp
-        this.comment = comment
-    }
-}
-
-
-class TimestampSerializer : StdSerializer<LocalDateTime> {
-
-    constructor() : super(LocalDateTime::class.java)
-
-    constructor(clazz: Class<LocalDateTime>) : super(clazz)
-
-    override fun serialize(value: LocalDateTime, gen: JsonGenerator, provider: SerializerProvider?) {
+@Component
+class DateTimeBean {
+    fun formatDateTime(date: LocalDateTime): Long {
         val zoneId = ZoneId.systemDefault()
-        val epoch = value.atZone(zoneId).toInstant().toEpochMilli()
-        gen.writeNumber(epoch)
+        return date.atZone(zoneId).toInstant().toEpochMilli()
     }
-
 }

--- a/src/main/java/backend/Teamoverview/TeamOverview.kt
+++ b/src/main/java/backend/Teamoverview/TeamOverview.kt
@@ -32,14 +32,14 @@ interface TeamOverview {
         val coord: Coord
         val locationData: Map<String, String>
 
-        @Value("#{@dateTimeBean.formatDateTime(target.date)}")
+        @Value("#{@teamOverviewBean.formatDateTime(target.date)}")
         fun getTimestamp(): Long
     }
 
     interface Posting {
         val id: Long
 
-        @Value("#{@dateTimeBean.formatDateTime(target.date)}")
+        @Value("#{@teamOverviewBean.formatDateTime(target.date)}")
         fun getTimestamp(): Long
     }
 
@@ -55,7 +55,10 @@ interface TeamOverview {
         val admin: Admin
         val comment: String?
 
-        @Value("#{@dateTimeBean.formatDateTime(target.createdAt)}")
+        @Value("#{@teamOverviewBean.formatReason(target.reason)}")
+        fun getReason(): Int
+
+        @Value("#{@teamOverviewBean.formatDateTime(target.createdAt)}")
         fun getTimestamp(): Long
     }
 
@@ -84,7 +87,12 @@ interface TeamOverview {
 }
 
 @Component
-class DateTimeBean {
+class TeamOverviewBean {
+
+    fun formatReason(reason: ContactWithHeadquarters.Reason): Int {
+        return reason.ordinal
+    }
+
     fun formatDateTime(date: LocalDateTime): Long {
         val zoneId = ZoneId.systemDefault()
         return date.atZone(zoneId).toInstant().toEpochMilli()

--- a/src/main/java/backend/Teamoverview/TeamOverview.kt
+++ b/src/main/java/backend/Teamoverview/TeamOverview.kt
@@ -1,4 +1,4 @@
-package backend.Teamoverview
+package backend.teamoverview
 
 import backend.model.misc.Coord
 import org.springframework.beans.factory.annotation.Value

--- a/src/main/java/backend/Teamoverview/TeamOverviewController.kt
+++ b/src/main/java/backend/Teamoverview/TeamOverviewController.kt
@@ -35,13 +35,13 @@ class TeamOverviewController(val teamOverviewService: TeamOverviewService,
                                  @AuthenticationPrincipal customUserDetails: CustomUserDetails) {
 
         val admin = userService.getUserFromCustomUserDetails(customUserDetails)
-        teamOverviewService.addComment(teamId, body.comment, admin.account)
+        teamOverviewService.addComment(teamId, body.reason, body.comment, admin.account)
     }
 
     class ContactCommentBody {
         @NotNull
-        @Size(min = 1)
-        lateinit var comment: String
+        lateinit var reason: ContactWithHeadquarters.Reason
+        var comment: String? = null
     }
 }
 

--- a/src/main/java/backend/Teamoverview/TeamOverviewController.kt
+++ b/src/main/java/backend/Teamoverview/TeamOverviewController.kt
@@ -1,7 +1,10 @@
 package backend.Teamoverview
 
+import backend.configuration.CustomUserDetails
+import backend.model.user.UserService
 import org.springframework.http.HttpStatus.CREATED
 import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
 import javax.validation.Valid
 import javax.validation.constraints.NotNull
@@ -9,7 +12,8 @@ import javax.validation.constraints.Size
 
 @RestController
 @RequestMapping("/teamoverview/")
-class TeamOverviewController(val teamOverviewService: TeamOverviewService) {
+class TeamOverviewController(val teamOverviewService: TeamOverviewService,
+                             val userService: UserService) {
 
     @GetMapping
     @PreAuthorize("hasAuthority('ADMIN')")
@@ -17,12 +21,21 @@ class TeamOverviewController(val teamOverviewService: TeamOverviewService) {
         return teamOverviewService.findAll()
     }
 
+    @GetMapping("{teamId}/calls/")
+    @PreAuthorize("hasAuthority('ADMIN')")
+    fun getCallsForTeam(@PathVariable teamId: Long): Iterable<ContactWithHeadquarters> {
+        return teamOverviewService.allCalls(teamId)
+    }
+
     @PostMapping("{teamId}/lastContactWithHeadquarters/")
     @PreAuthorize("hasAuthority('ADMIN')")
     @ResponseStatus(CREATED)
     fun addContactCommentForTeam(@PathVariable teamId: Long,
-                                 @Valid @RequestBody body: ContactCommentBody) {
-        teamOverviewService.addComment(teamId, body.comment)
+                                 @Valid @RequestBody body: ContactCommentBody,
+                                 @AuthenticationPrincipal customUserDetails: CustomUserDetails) {
+
+        val admin = userService.getUserFromCustomUserDetails(customUserDetails)
+        teamOverviewService.addComment(teamId, body.comment, admin.account)
     }
 
     class ContactCommentBody {

--- a/src/main/java/backend/Teamoverview/TeamOverviewController.kt
+++ b/src/main/java/backend/Teamoverview/TeamOverviewController.kt
@@ -1,4 +1,4 @@
-package backend.Teamoverview
+package backend.teamoverview
 
 import backend.configuration.CustomUserDetails
 import backend.model.user.UserService

--- a/src/main/java/backend/Teamoverview/TeamOverviewService.kt
+++ b/src/main/java/backend/Teamoverview/TeamOverviewService.kt
@@ -1,8 +1,10 @@
 package backend.Teamoverview
 
+import backend.model.user.UserAccount
+
 interface TeamOverviewService {
     fun findAll(): Iterable<TeamOverview>
-    fun findByTeamId(teamId: Long): TeamOverview?
-    fun addComment(teamId: Long, comment: String)
+    fun allCalls(teamId: Long): Iterable<ContactWithHeadquarters>
+    fun addComment(teamId: Long, comment: String, admin: UserAccount)
 }
 

--- a/src/main/java/backend/Teamoverview/TeamOverviewService.kt
+++ b/src/main/java/backend/Teamoverview/TeamOverviewService.kt
@@ -5,6 +5,9 @@ import backend.model.user.UserAccount
 interface TeamOverviewService {
     fun findAll(): Iterable<TeamOverview>
     fun allCalls(teamId: Long): Iterable<ContactWithHeadquarters>
-    fun addComment(teamId: Long, comment: String, admin: UserAccount)
+    fun addComment(teamId: Long,
+                   reason: ContactWithHeadquarters.Reason,
+                   comment: String?,
+                   admin: UserAccount)
 }
 

--- a/src/main/java/backend/Teamoverview/TeamOverviewService.kt
+++ b/src/main/java/backend/Teamoverview/TeamOverviewService.kt
@@ -1,4 +1,4 @@
-package backend.Teamoverview
+package backend.teamoverview
 
 import backend.model.user.UserAccount
 

--- a/src/main/java/backend/Teamoverview/TeamOverviewServiceImpl.kt
+++ b/src/main/java/backend/Teamoverview/TeamOverviewServiceImpl.kt
@@ -18,9 +18,13 @@ class TeamOverviewServiceImpl(
             contactWithHeadquartersRepository.findAllByTeamId(teamId)
 
     @Transactional
-    override fun addComment(teamId: Long, comment: String, admin: UserAccount) {
+    override fun addComment(teamId: Long,
+                            reason: ContactWithHeadquarters.Reason,
+                            comment: String?,
+                            admin: UserAccount) {
+
         val team = teamRepository.findById(teamId) ?: return
-        val contact = ContactWithHeadquarters(team, comment, admin)
+        val contact = ContactWithHeadquarters(team, reason, comment, admin)
         contactWithHeadquartersRepository.save(contact)
     }
 }

--- a/src/main/java/backend/Teamoverview/TeamOverviewServiceImpl.kt
+++ b/src/main/java/backend/Teamoverview/TeamOverviewServiceImpl.kt
@@ -1,7 +1,6 @@
-package backend.Teamoverview
+package backend.teamoverview
 
 import backend.model.event.*
-import backend.model.user.Admin
 import backend.model.user.UserAccount
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional

--- a/src/main/java/backend/Teamoverview/TeamOverviewServiceImpl.kt
+++ b/src/main/java/backend/Teamoverview/TeamOverviewServiceImpl.kt
@@ -1,82 +1,27 @@
 package backend.Teamoverview
 
-import backend.controller.exceptions.NotFoundException
-import backend.model.event.Event
-import backend.model.event.Team
-import backend.model.event.TeamChangedEvent
-import backend.model.event.TeamCreatedEvent
-import backend.model.location.LocationUploadedEvent
-import backend.model.posting.PostingCreatedEvent
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
+import backend.model.event.*
+import backend.model.user.Admin
+import backend.model.user.UserAccount
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDateTime
-import javax.persistence.NonUniqueResultException
 
 @Service
-class TeamOverviewServiceImpl(private val teamOverviewRepository: TeamoverviewRepository) : TeamOverviewService {
+class TeamOverviewServiceImpl(
+        private val teamRepository: TeamRepository,
+        private val contactWithHeadquartersRepository: ContactWithHeadquartersRepository
+) : TeamOverviewService {
 
-    private val logger: Logger = LoggerFactory.getLogger(TeamOverviewServiceImpl::class.java)
+    override fun findAll(): Iterable<TeamOverview> =
+            teamRepository.findAllByEventIsCurrentTrueAndHasStartedTrue()
 
-    override fun findAll(): Iterable<TeamOverview> = teamOverviewRepository.findAll()
-
-    override fun findByTeamId(teamId: Long): TeamOverview? = teamOverviewRepository.findByTeamId(teamId)
+    override fun allCalls(teamId: Long): Iterable<ContactWithHeadquarters> =
+            contactWithHeadquartersRepository.findAllByTeamId(teamId)
 
     @Transactional
-    override fun addComment(teamId: Long, comment: String) {
-        val teamOverview = this.findByTeamId(teamId)
-                ?: throw NotFoundException("Team with id $teamId not found in TeamOverview")
-
-        val previousComment = teamOverview.lastContactWithHeadquarters?.comment ?: ""
-        val newComment = "$previousComment----$comment"
-        teamOverview.setLastContactWithHeadquarters(newComment, LocalDateTime.now())
-    }
-
-    //@EventListener
-    fun onTeamCreated(teamCreatedEvent: TeamCreatedEvent) {
-        val overview = TeamOverview(teamCreatedEvent.team, teamCreatedEvent.team.event)
-        teamOverviewRepository.save(overview)
-    }
-
-    //@EventListener
-    fun onTeamChanged(teamChangedEvent: TeamChangedEvent) {
-        val team = teamChangedEvent.team
-        val overview = teamOverviewRepository.findByTeamId(team.id!!) ?: createOverviewForTeam(team)
-        overview.setOrUpdateValues(team.event, team)
-        teamOverviewRepository.save(overview)
-    }
-
-    //@EventListener
-    fun onLocationUploaded(locationUploadedEvent: LocationUploadedEvent) {
-        try {
-            val team = locationUploadedEvent.team
-            val overview = teamOverviewRepository.findByTeamId(team.id!!) ?: createOverviewForTeam(team)
-            overview.lastLocation = LastLocation(locationUploadedEvent.location)
-            teamOverviewRepository.save(overview)
-        } catch (e: NonUniqueResultException) {
-            logger.error("Failed to update TeamOverview" +
-                    e.message)
-        }
-    }
-
-    //@EventListener
-    fun onPostingCreated(postingCreatedEvent: PostingCreatedEvent) {
-        val posting = postingCreatedEvent.posting
-        val team = posting.team ?: run {
-            logger.warn("Posting ${posting.id} was ignored because it has no team")
-            return
-        }
-
-        val overview = teamOverviewRepository.findByTeamId(team.id!!) ?: createOverviewForTeam(team)
-        overview.lastPosting = LastPosting(posting.id!!, posting.createdAt!!)
-        teamOverviewRepository.save(overview)
-    }
-
-    private fun createOverviewForTeam(team: Team): TeamOverview {
-        return TeamOverview(team, team.event)
+    override fun addComment(teamId: Long, comment: String, admin: UserAccount) {
+        val team = teamRepository.findById(teamId) ?: return
+        val contact = ContactWithHeadquarters(team, comment, admin)
+        contactWithHeadquartersRepository.save(contact)
     }
 }
-
-// TODO: Fire those where appropriate
-class EventChangedEvent(val event: Event)

--- a/src/main/java/backend/Teamoverview/TeamoverviewRepository.kt
+++ b/src/main/java/backend/Teamoverview/TeamoverviewRepository.kt
@@ -1,8 +1,0 @@
-package backend.Teamoverview
-
-import org.springframework.data.repository.CrudRepository
-
-interface TeamoverviewRepository : CrudRepository<TeamOverview, Long> {
-    fun findByTeamId(teamId: Long): TeamOverview?
-}
-

--- a/src/main/java/backend/controller/TeamController.kt
+++ b/src/main/java/backend/controller/TeamController.kt
@@ -136,6 +136,7 @@ class TeamController(private val teamService: TeamService,
         team.description = body.description ?: team.description
         team.name = body.name ?: team.name
         team.profilePic = body.profilePic?.let(::Media) ?: team.profilePic
+        team.asleep = body.asleep ?: team.asleep
 
         teamService.save(team)
 

--- a/src/main/java/backend/model/event/Team.kt
+++ b/src/main/java/backend/model/event/Team.kt
@@ -43,6 +43,8 @@ class Team : BasicEntity, Blockable {
 
     var hasStarted: Boolean = false
 
+    var asleep: Boolean = false
+
     lateinit var name: String
 
     @ManyToOne(fetch = LAZY)

--- a/src/main/java/backend/model/event/TeamRepository.kt
+++ b/src/main/java/backend/model/event/TeamRepository.kt
@@ -1,6 +1,6 @@
 package backend.model.event
 
-import backend.Teamoverview.TeamOverview
+import backend.teamoverview.TeamOverview
 import backend.model.location.Location
 import backend.model.posting.Posting
 import org.springframework.data.domain.Pageable

--- a/src/main/java/backend/model/event/TeamRepository.kt
+++ b/src/main/java/backend/model/event/TeamRepository.kt
@@ -1,5 +1,6 @@
 package backend.model.event
 
+import backend.Teamoverview.TeamOverview
 import backend.model.location.Location
 import backend.model.posting.Posting
 import org.springframework.data.domain.Pageable
@@ -30,5 +31,9 @@ interface TeamRepository : CrudRepository<Team, Long> {
     @Query("from Team t where t.name like concat('%',:search,'%')")
     fun searchByString(@Param("search") search: String): List<Team>
 
+    fun findAllByEventIsCurrentTrueAndHasStartedTrue(): Iterable<TeamOverview>
+
     fun findAllByEventIsCurrentTrueOrderByName(): Iterable<TeamSummaryProjection>
 }
+
+

--- a/src/main/java/backend/model/location/LocationRepository.kt
+++ b/src/main/java/backend/model/location/LocationRepository.kt
@@ -17,4 +17,13 @@ interface LocationRepository : CrudRepository<Location, Long> {
 
     @Query("Select l from Location l WHERE l.team.id = :id AND l.date <= :date AND l.id != :locationId order by l.date desc")
     fun findByTeamIdAndPriorOrderByDateDesc(@Param("id") id: Long?, @Param("locationId") locationId: Long?, @Param("date") date: LocalDateTime): List<Location>
+
+    @Query("""
+        select *
+        from location
+        where team_id = :id
+        order by id desc
+        limit 1
+    """, nativeQuery = true)
+    fun findLastLocationByTeamId(@Param("id") id: Long): Location?
 }

--- a/src/main/java/backend/model/location/LocationServiceImpl.kt
+++ b/src/main/java/backend/model/location/LocationServiceImpl.kt
@@ -10,7 +10,6 @@ import backend.model.user.Participant
 import backend.services.FeatureFlagService
 import backend.services.GeoCodingService
 import backend.util.speedToLocation
-import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
 import javax.transaction.Transactional
@@ -19,8 +18,7 @@ import javax.transaction.Transactional
 class LocationServiceImpl(private val locationRepository: LocationRepository,
                           private val geoCodingService: GeoCodingService,
                           private val featureFlagService: FeatureFlagService,
-                          private val eventService: EventService,
-                          private val eventPublisher: ApplicationEventPublisher) : LocationService {
+                          private val eventService: EventService) : LocationService {
 
     override fun findAll(): Iterable<Location> {
         return locationRepository.findAll()
@@ -47,7 +45,6 @@ class LocationServiceImpl(private val locationRepository: LocationRepository,
 
         val savedLocation = locationRepository.save(location)
         val team = location.team ?: throw Exception("Location has no team")
-        //eventPublisher.publishEvent(LocationUploadedEvent(location, team))
         return savedLocation
     }
 
@@ -123,5 +120,3 @@ class LocationServiceImpl(private val locationRepository: LocationRepository,
             locationRepository.findByTeamIdAndPriorOrderByDateDesc(location.team?.id, location.id, location.date).firstOrNull()
 
 }
-
-class LocationUploadedEvent(val location: Location, val team: Team)

--- a/src/main/java/backend/model/posting/PostingRepository.kt
+++ b/src/main/java/backend/model/posting/PostingRepository.kt
@@ -17,4 +17,14 @@ interface PostingRepository : CrudRepository<Posting, Long> {
 
     @Query("select p from Posting p where p.reported = true")
     fun findReported(): List<Posting>
+
+
+    @Query("""
+        select *
+        from posting
+        where team_id = :id
+        order by id desc
+        limit 1
+    """, nativeQuery = true)
+    fun findLastPostingByTeamId(@Param("id") id: Long): Posting?
 }

--- a/src/main/java/backend/model/posting/PostingServiceImpl.kt
+++ b/src/main/java/backend/model/posting/PostingServiceImpl.kt
@@ -11,7 +11,6 @@ import backend.model.user.Participant
 import backend.model.user.User
 import backend.model.user.UserAccount
 import backend.services.NotificationService
-import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -21,8 +20,7 @@ import java.time.LocalDateTime
 class PostingServiceImpl(private val repository: PostingRepository,
                          private val notificationService: NotificationService,
                          private val locationService: LocationService,
-                         private val mediaService: MediaService,
-                         private val applicationEventPublisher: ApplicationEventPublisher) : PostingService {
+                         private val mediaService: MediaService) : PostingService {
 
     override fun removeComment(posting: Posting, commentId: Long) {
         posting.removeComment(commentId)
@@ -84,7 +82,6 @@ class PostingServiceImpl(private val repository: PostingRepository,
             savedMedia = mediaService.save(media)
         }
 
-        //applicationEventPublisher.publishEvent(PostingCreatedEvent(posting))
         return repository.save(Posting(text, date, location, user, savedMedia))
     }
 
@@ -145,5 +142,3 @@ class PostingServiceImpl(private val repository: PostingRepository,
         repository.delete(posting)
     }
 }
-
-class PostingCreatedEvent(val posting: Posting)

--- a/src/main/java/backend/view/TeamView.kt
+++ b/src/main/java/backend/view/TeamView.kt
@@ -4,6 +4,7 @@ import backend.model.event.Team
 import backend.model.removeBlockedBy
 import backend.util.data.DonateSums
 import backend.view.user.BasicUserView
+import com.sun.org.apache.xpath.internal.operations.Bool
 import org.hibernate.validator.constraints.SafeHtml
 import org.hibernate.validator.constraints.SafeHtml.WhiteListType.NONE
 import java.util.*
@@ -41,6 +42,8 @@ class TeamView() {
 
     var score: Double? = null
 
+    var asleep: Boolean? = null
+
     constructor(team: Team, userId: Long?) : this() {
         this.id = team.id
         this.name = team.name
@@ -55,6 +58,7 @@ class TeamView() {
         this.hasStarted = team.hasStarted
         this.hasFullyPaid = team.invoice?.isFullyPaid()
         this.isFull = team.isFull()
+        this.asleep = team.asleep
     }
 
     constructor(team: Team, distance: Double, donateSum: DonateSums, score: Double, userId: Long?) : this() {
@@ -74,5 +78,6 @@ class TeamView() {
         this.distance = distance
         this.donateSum = donateSum
         this.score = score
+        this.asleep = team.asleep
     }
 }

--- a/src/main/resources/db/migration/V201904050000__refactored_teamoverview.sql
+++ b/src/main/resources/db/migration/V201904050000__refactored_teamoverview.sql
@@ -10,9 +10,10 @@ CREATE TABLE `contact_with_headquarters` (
   `updated_at` datetime DEFAULT NULL,
   `team_id` bigint(20) NOT NULL,
   `admin_id` bigint(20) NOT NULL,
-  `comment` varchar(255) DEFAULT NULL,
+  `reason` int(11) NOT NULL,
+  `comment` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+)
 
 -- Add going to sleep column
 alter table team add column `asleep` BIT DEFAULT 0;

--- a/src/main/resources/db/migration/V201904050000__refactored_teamoverview.sql
+++ b/src/main/resources/db/migration/V201904050000__refactored_teamoverview.sql
@@ -13,3 +13,6 @@ CREATE TABLE `contact_with_headquarters` (
   `comment` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+-- Add going to sleep column
+alter table team add column `asleep` BIT DEFAULT 0;

--- a/src/main/resources/db/migration/V201904050000__refactored_teamoverview.sql
+++ b/src/main/resources/db/migration/V201904050000__refactored_teamoverview.sql
@@ -1,0 +1,15 @@
+
+--  (╯°□°）╯︵ ┻━┻ I said a droppa da table
+drop table team_overview_location_data;
+drop table team_overview_members;
+drop table team_overview;
+
+CREATE TABLE `contact_with_headquarters` (
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `created_at` datetime DEFAULT NULL,
+  `updated_at` datetime DEFAULT NULL,
+  `team_id` bigint(20) NOT NULL,
+  `admin_id` bigint(20) NOT NULL,
+  `comment` varchar(255) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/src/test/java/backend/Integration/IntegrationTest.kt
+++ b/src/test/java/backend/Integration/IntegrationTest.kt
@@ -1,7 +1,6 @@
 package backend.Integration
 
 
-import backend.Teamoverview.TeamoverviewRepository
 import backend.TestBackendConfiguration
 import backend.configuration.AuthorizationServerConfiguration
 import backend.configuration.ResourceServerConfiguration
@@ -80,7 +79,6 @@ abstract class IntegrationTest {
     @Autowired lateinit protected var challengeRepository: ChallengeRepository
     @Autowired lateinit protected var featureRepository: FeatureRepository
     @Autowired lateinit protected var sponsoringInvoiceRepository: SponsoringInvoiceRepository
-    @Autowired lateinit protected var teamOverviewRepository: TeamoverviewRepository
 
     // Services
     @Autowired lateinit protected var userService: UserService
@@ -112,7 +110,6 @@ abstract class IntegrationTest {
         challengeRepository.deleteAll()
         sponsoringRepository.deleteAll()
         featureRepository.deleteAll()
-        teamOverviewRepository.deleteAll()
         mockMvc = MockMvcBuilders
                 .webAppContextSetup(context)
                 .addFilters<DefaultMockMvcBuilder>(springSecurityFilterChain)


### PR DESCRIPTION
This changes the event based implementation to a computed one and it's therefore now officially live!

Performance improvements still could to be made. On my MacBook a request to all the overviews for 2018 takes about 1.5 to 2 seconds. Which is acceptable but could be better.
- Unrelated left joins could not be made without JPA 2.something and Hibernate 5.1
- Therefore each check for the last call, location or posting is moved to a service instead of to a single query (trust me I tried)

To be done:
- Team event has some new requirements on what to store into the last contact with hq:
   - Reason for the call?
   - Who made the call?
   - Current location that they said on the phone (that's the harder one)
- Also they asked if they can get the call history as well.

Also future possibilities:
- Move the component to be react based
- Auto refreshing every 10 mins.
- Hide emergency contact (make sure no one uses that one instead of the regular one) (apparently it's a whole thing)