### PR TITLE
Admin Performance improvements

### DIFF
--- a/src/main/java/backend/controller/TeamController.kt
+++ b/src/main/java/backend/controller/TeamController.kt
@@ -22,6 +22,7 @@ import backend.util.CacheNames.POSTINGS
 import backend.util.CacheNames.TEAMS
 import backend.util.data.DonateSums
 import backend.view.InvitationView
+import backend.view.TeamAndTeamEntryFeeInvoiceView
 import backend.view.TeamView
 import backend.view.posting.PostingView
 import org.slf4j.Logger
@@ -275,5 +276,12 @@ class TeamController(private val teamService: TeamService,
     @GetMapping("/{id}/donatesum/")
     fun getTeamDonateSum(@PathVariable("id") teamId: Long): DonateSums {
         return teamService.getDonateSum(teamId)
+    }
+
+
+    @PreAuthorize("hasAuthority('ADMIN')")
+    @GetMapping("/teamfee/")
+    fun getTeamFees(@PathVariable eventId: Long): Iterable<TeamAndTeamEntryFeeInvoiceView> {
+        return teamService.findByEventId(eventId).map(::TeamAndTeamEntryFeeInvoiceView)
     }
 }

--- a/src/main/java/backend/controller/exceptions/SponsoringInvoiceController.kt
+++ b/src/main/java/backend/controller/exceptions/SponsoringInvoiceController.kt
@@ -2,6 +2,7 @@ package backend.controller.exceptions
 
 import backend.model.event.EventService
 import backend.model.payment.SponsoringInvoiceService
+import backend.util.euroOf
 import backend.view.sponsoring.DetailedSponsoringInvoiceView
 import backend.view.sponsoring.SponsoringInvoiceView
 import org.slf4j.LoggerFactory
@@ -90,5 +91,22 @@ class SponsoringInvoiceController(private val sponsoringInvoiceService: Sponsori
         } else {
             sponsoringInvoiceService.findByEventId(eventId).map(::SponsoringInvoiceView)
         }
+    }
+
+    @GetMapping("/search/")
+    @PreAuthorize("hasAuthority('ADMIN')")
+    fun searchInvoices(@RequestParam(required = false) purposeOfTransferCode: String?,
+                       @RequestParam(required = false) teamId: Long?,
+                       @RequestParam(required = false) eventId: Long?,
+                       @RequestParam(required = false) firstname: String?,
+                       @RequestParam(required = false) lastname: String?,
+                       @RequestParam(required = false) company: String?,
+                       @RequestParam(required = false) minDonation: Number?,
+                       @RequestParam(required = false) maxDonation: Number?,
+                       @RequestParam(required = false) donorType: String?): Iterable<SponsoringInvoiceView> {
+
+        return sponsoringInvoiceService
+                .findByFilters(purposeOfTransferCode, teamId, eventId, firstname, lastname, company, minDonation?.let(::euroOf), maxDonation?.let(::euroOf), donorType)
+                .map(::SponsoringInvoiceView)
     }
 }

--- a/src/main/java/backend/model/payment/SponsoringInvoiceRepository.kt
+++ b/src/main/java/backend/model/payment/SponsoringInvoiceRepository.kt
@@ -6,6 +6,12 @@ import org.springframework.data.repository.query.Param
 
 interface SponsoringInvoiceRepository : CrudRepository<SponsoringInvoice, Long> {
 
+    @Query("""
+        from SponsoringInvoice
+        where (registeredSponsor is not null and registeredSponsor.supporterType is not null) or unregisteredSponsor is not null
+    """)
+    override fun findAll(): Iterable<SponsoringInvoice>
+
     @Query("from SponsoringInvoice where registeredSponsor.id = :registeredSponsorId")
     fun findBySponsorId(@Param("registeredSponsorId") registeredSponsorId: Long): Iterable<SponsoringInvoice>
 

--- a/src/main/java/backend/model/payment/SponsoringInvoiceService.kt
+++ b/src/main/java/backend/model/payment/SponsoringInvoiceService.kt
@@ -20,6 +20,8 @@ interface SponsoringInvoiceService {
 
     fun findByEventId(eventId: Long): Iterable<SponsoringInvoice>
 
+    fun findByFilters(transferCode: String?, teamId: Long?, eventId: Long?, firstName: String?, lastName: String?, company: String?, minDonationSum: Money?, maxDonationSum: Money?, donorType: String?): Iterable<SponsoringInvoice>
+
     fun save(invoice: SponsoringInvoice): SponsoringInvoice
 
     fun addAdminPaymentToInvoice(admin: Admin, amount: Money, invoice: SponsoringInvoice, date: LocalDateTime?, fidorId: Long?): SponsoringInvoice

--- a/src/main/java/backend/model/payment/SponsoringInvoiceServiceImpl.kt
+++ b/src/main/java/backend/model/payment/SponsoringInvoiceServiceImpl.kt
@@ -68,6 +68,37 @@ class SponsoringInvoiceServiceImpl(private val sponsoringInvoiceRepository: Spon
         return sponsoringInvoiceRepository.findAllByEventId(eventId)
     }
 
+    override fun findByFilters(purposeOfTransferCode: String?,
+                               teamId: Long?,
+                               eventId: Long?,
+                               firstname: String?,
+                               lastname: String?,
+                               company: String?,
+                               minDonation: Money?,
+                               maxDonation: Money?,
+                               donorType: String?): Iterable<SponsoringInvoice> {
+
+        val invoices = purposeOfTransferCode?.let {
+            arrayOf(sponsoringInvoiceRepository.findByPurposeOfTransferCode(purposeOfTransferCode))
+                    .mapNotNull { it }
+        } ?: teamId?.let {
+            sponsoringInvoiceRepository.findByTeamId(it)
+        } ?: eventId?.let {
+            sponsoringInvoiceRepository.findAllByEventId(it)
+        } ?: sponsoringInvoiceRepository.findAll()
+
+        return invoices
+                .filterBy(purposeOfTransferCode) { purposeOfTransferCode, invoice -> purposeOfTransferCode == invoice.purposeOfTransferCode }
+                .filterBy(eventId) { eventId, invoice -> eventId == invoice.event?.id }
+                .filterBy(firstname) { firstname, invoice -> invoice.sponsor.firstname?.contains(firstname, ignoreCase = true) ?: false }
+                .filterBy(lastname) { lastname, invoice -> invoice.sponsor.lastname?.contains(lastname, ignoreCase = true) ?: false }
+                .filterBy(company) { company, invoice -> invoice.sponsor.company?.contains(company, ignoreCase = true) ?: false }
+                .filterBy(minDonation) { minDonation, invoice -> minDonation <= invoice.amount }
+                .filterBy(maxDonation) { maxDonation, invoice -> maxDonation >= invoice.amount }
+                .filterBy(donorType) { donorType, invoice -> donorType == invoice.sponsor.supporterType.name }
+
+    }
+
     override fun findByPurposeOfTransferCode(purposeOfTransferCode: String): SponsoringInvoice? {
         return sponsoringInvoiceRepository.findByPurposeOfTransferCode(purposeOfTransferCode)
     }
@@ -186,3 +217,6 @@ class SponsoringInvoiceServiceImpl(private val sponsoringInvoiceRepository: Spon
 
 }
 
+private fun <T, V> Iterable<T>.filterBy(value: V?, predicate: (V, T) -> Boolean): Iterable<T> {
+    return value?.let { value -> filter { predicate(value, it) } } ?: this
+}

--- a/src/main/java/backend/view/TeamAndTeamEntryFeeInvoiceView.kt
+++ b/src/main/java/backend/view/TeamAndTeamEntryFeeInvoiceView.kt
@@ -1,0 +1,16 @@
+package backend.view
+
+import backend.model.event.Team
+
+class TeamAndTeamEntryFeeInvoiceView {
+
+    var team: TeamView? = null
+    var invoice: TeamEntryFeeInvoiceView? = null
+
+    constructor()
+
+    constructor(team: Team) {
+        this.team = TeamView(team, null)
+        this.invoice = team.invoice?.let(::TeamEntryFeeInvoiceView)
+    }
+}


### PR DESCRIPTION
- Adds 2 endpoints:
  - `/event/{id}/team/teamfee/` that loads all the teams and their invoices
  - `/sponsoringinvoice/search/` to search invoices via filters

Also:
- Fixes issue with sponsoring invoices that crash because they have no donor type or sponsor