### PR TITLE
Add team name and id to posting view

### DIFF
--- a/src/main/java/backend/view/posting/PostingResponseView.kt
+++ b/src/main/java/backend/view/posting/PostingResponseView.kt
@@ -41,6 +41,9 @@ class PostingResponseView() {
 
     var proves: PostingChallengeView? = null
 
+    var teamId: Long? = null
+
+    var teamName: String? = null
 
     constructor(posting: Posting, challenge: ChallengeProofProjection?, userId: Long?) : this() {
         this.id = posting.id
@@ -54,5 +57,7 @@ class PostingResponseView() {
         this.likes = posting.likes.count()
         this.hasLiked = posting.hasLiked
         this.proves = challenge?.let(::PostingChallengeView)
+        this.teamName = posting.team?.name
+        this.teamId = posting.team?.id
     }
 }


### PR DESCRIPTION
We need this for displaying the proper team name
with postings instead of a users current team, which
could result in invalid team names for users that have
a new team and an old team