### PR TITLE
Open deleteComment for users so they can delete their own comments

### DIFF
--- a/src/main/java/backend/controller/PostingController.kt
+++ b/src/main/java/backend/controller/PostingController.kt
@@ -173,7 +173,7 @@ class PostingController(private val postingService: PostingService,
 
         val user = userService.getUserFromCustomUserDetails(customUserDetails)
         if (!user.hasAuthority(EventManager::class) && comment.user?.id != customUserDetails.id) {
-            throw UnauthorizedException("Users can only delete comments submitted by themselves")
+            throw ForbiddenException("Users can only delete comments submitted by themselves")
         }
 
         postingService.removeComment(from = posting, id = commentId)

--- a/src/main/java/backend/controller/PostingController.kt
+++ b/src/main/java/backend/controller/PostingController.kt
@@ -146,7 +146,7 @@ class PostingController(private val postingService: PostingService,
         val posting = postingService.getByID(id) ?: throw NotFoundException("posting with id $id does not exist")
         val user = userService.getUserFromCustomUserDetails(customUserDetails)
         if (!user.hasAuthority(EventManager::class) && posting.user?.id != customUserDetails.id) {
-            throw UnauthorizedException("A user can only delete postings submitted by itself")
+            throw UnauthorizedException("Users can only delete postings submitted by themselves")
         }
 
         posting.challenge?.let {
@@ -156,17 +156,26 @@ class PostingController(private val postingService: PostingService,
         return mapOf("message" to "success")
     }
 
+
     /**
      * DELETE /posting/{id}/comment/{commentId}/
-     * Allows Admin to delete Comment
+     * Allows Admin or author to delete Comment
      */
     @CacheEvict(value = POSTINGS, allEntries = true)
-    @PreAuthorize("hasAuthority('EVENT_MANAGER')")
+    @PreAuthorize("isAuthenticated()")
     @RequestMapping("/{id}/comment/{commentId}/", method = [DELETE])
-    fun adminDeleteComment(@PathVariable("id") postingId: Long,
-                           @PathVariable("commentId") commentId: Long): Map<String, String> {
+    fun deleteComment(@PathVariable("id") postingId: Long,
+                      @PathVariable("commentId") commentId: Long,
+                      @AuthenticationPrincipal customUserDetails: CustomUserDetails): Map<String, String> {
 
         val posting = postingService.getByID(postingId) ?: throw NotFoundException("Posting with id $postingId not found")
+        val comment = posting.findCommentById(commentId) ?: throw NotFoundException("Comment with id $commentId not found for posting with id $postingId")
+
+        val user = userService.getUserFromCustomUserDetails(customUserDetails)
+        if (!user.hasAuthority(EventManager::class) && comment.user?.id != customUserDetails.id) {
+            throw UnauthorizedException("Users can only delete comments submitted by themselves")
+        }
+
         postingService.removeComment(from = posting, id = commentId)
 
         return mapOf("message" to "success")

--- a/src/main/java/backend/controller/exceptions/Exceptions.kt
+++ b/src/main/java/backend/controller/exceptions/Exceptions.kt
@@ -10,6 +10,9 @@ class NotFoundException(message: String) : RuntimeException(message)
 @ResponseStatus(HttpStatus.UNAUTHORIZED)
 class UnauthorizedException(message: String) : RuntimeException(message)
 
+@ResponseStatus(HttpStatus.FORBIDDEN)
+class ForbiddenException(message: String) : RuntimeException(message)
+
 @ResponseStatus(HttpStatus.BAD_REQUEST)
 class BadRequestException(message: String) : RuntimeException(message)
 

--- a/src/main/java/backend/model/posting/Posting.kt
+++ b/src/main/java/backend/model/posting/Posting.kt
@@ -139,7 +139,7 @@ class Posting : BasicEntity, UserGenerated, Reportable {
         return this
     }
 
-    private fun findCommentById(commentId: Long): Comment? {
+    public fun findCommentById(commentId: Long): Comment? {
         return this.comments.firstOrNull { it.id == commentId }
     }
 

--- a/src/test/java/backend/Integration/TestPostingEndpoint.kt
+++ b/src/test/java/backend/Integration/TestPostingEndpoint.kt
@@ -118,7 +118,7 @@ open class TestPostingEndpoint : IntegrationTest() {
     }
 
     @Test
-    open fun adminDeleteComment() {
+    open fun deleteCommentAsAdmin() {
 
         val posting = postingService.savePostingWithLocationAndMedia("Test", null, user.account, null, LocalDateTime.now())
 //        val comment = commentService.createComment("TestComment", LocalDateTime.now(), posting, user.account)
@@ -172,11 +172,65 @@ open class TestPostingEndpoint : IntegrationTest() {
     }
 
     @Test
-    open fun adminDeleteCommentFailNotAdmin() {
+    open fun deleteCommentAsUser() {
 
         val posting = postingService.savePostingWithLocationAndMedia("Test", null, user.account, null, LocalDateTime.now())
+//        val comment = commentService.createComment("TestComment", LocalDateTime.now(), posting, user.account)
+        postingService.addComment(posting, user.account, LocalDateTime.now(), "TestComment")
+        val requestPosting = get("/posting/${posting.id}/")
+
+        mockMvc.perform(requestPosting)
+                .andExpect(status().isOk)
+                .andExpect(content().contentType(APPLICATION_JSON_UTF_8))
+                .andExpect(jsonPath("$.id").exists())
+                .andExpect(jsonPath("$.text").exists())
+                .andExpect(jsonPath("$.date").exists())
+                .andExpect(jsonPath("$.user").exists())
+                .andExpect(jsonPath("$.comments").isArray)
+                .andExpect(jsonPath("$.comments[0].text").value("TestComment"))
+
+        fun MockHttpServletResponse.asMap(): Map<String, Any> {
+            val mapper = ObjectMapper()
+            val body = this.contentAsString
+
+            return mapper.readValue(body, Map::class.java) as Map<String, Any>
+        }
+
+        val comments: List<Map<String, Any>> = mockMvc.perform(get("/posting/${posting.id}/"))
+                .andReturn().response.asMap()["comments"]!! as List<Map<String, Any>>
+
+        val commentId = comments.first()["id"]!!
+
+        val requestDelete = MockMvcRequestBuilders
+                .delete("/posting/${posting.id}/comment/$commentId/")
+                .asUser(mockMvc, user.email, "password")
+
+        mockMvc.perform(requestDelete)
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.message").exists())
+                .andExpect(jsonPath("$.message").value("success"))
+
+
+        val requestPosting2 = get("/posting/${posting.id}/")
+
+        mockMvc.perform(requestPosting2)
+                .andExpect(status().isOk)
+                .andExpect(content().contentType(APPLICATION_JSON_UTF_8))
+                .andExpect(jsonPath("$.id").exists())
+                .andExpect(jsonPath("$.text").exists())
+                .andExpect(jsonPath("$.date").exists())
+                .andExpect(jsonPath("$.user").exists())
+                .andExpect(jsonPath("$.comments").isArray)
+                .andExpect(jsonPath("$.comments[0]").doesNotExist())
+
+    }
+
+    @Test
+    open fun deleteCommentFailNotAdminOrPoster() {
+
+        val posting = postingService.savePostingWithLocationAndMedia("Test", null, admin.account, null, LocalDateTime.now())
         //val comment = commentService.createComment("TestComment", LocalDateTime.now(), posting, user.account)
-        val comment = postingService.addComment(posting, user.account, LocalDateTime.now(), "Hello!")
+        val comment = postingService.addComment(posting, admin.account, LocalDateTime.now(), "Hello!")
         val requestPosting = get("/posting/${posting.id}/")
 
         mockMvc.perform(requestPosting)

--- a/src/test/java/backend/Integration/TestPostingEndpoint.kt
+++ b/src/test/java/backend/Integration/TestPostingEndpoint.kt
@@ -32,6 +32,7 @@ open class TestPostingEndpoint : IntegrationTest() {
     private lateinit var configurationService: ConfigurationService
     private lateinit var JWT_SECRET: String
     private lateinit var user: User
+    private lateinit var user2: User
     private lateinit var admin: User
     private lateinit var event: Event
     private lateinit var team: Team
@@ -45,6 +46,7 @@ open class TestPostingEndpoint : IntegrationTest() {
         event = eventService.createEvent("Breakout München", LocalDateTime.now(), "Munich", Coord(1.0, 1.0), 36)
         admin = userService.create("test_admin@break-out.org", "password", { addRole(Admin::class); isBlocked = false })
         user = userService.create("test@mail.com", "password", { addRole(Participant::class) })
+        user2 = userService.create("test2@mail.com", "password", { addRole(Participant::class) })
         team = teamService.create(user.getRole(Participant::class)!!, "name", "description", event, null)
     }
 
@@ -228,9 +230,9 @@ open class TestPostingEndpoint : IntegrationTest() {
     @Test
     open fun deleteCommentFailNotAdminOrPoster() {
 
-        val posting = postingService.savePostingWithLocationAndMedia("Test", null, admin.account, null, LocalDateTime.now())
+        val posting = postingService.savePostingWithLocationAndMedia("Test", null, user.account, null, LocalDateTime.now())
         //val comment = commentService.createComment("TestComment", LocalDateTime.now(), posting, user.account)
-        val comment = postingService.addComment(posting, admin.account, LocalDateTime.now(), "Hello!")
+        val comment = postingService.addComment(posting, user.account, LocalDateTime.now(), "Hello!")
         val requestPosting = get("/posting/${posting.id}/")
 
         mockMvc.perform(requestPosting)
@@ -258,7 +260,7 @@ open class TestPostingEndpoint : IntegrationTest() {
 
         val requestDelete = MockMvcRequestBuilders
                 .delete("/posting/${posting.id}/comment/$commentId/")
-                .asUser(mockMvc, user.email, "password")
+                .asUser(mockMvc, user2.email, "password")
 
         mockMvc.perform(requestDelete)
                 .andExpect(status().isForbidden)


### PR DESCRIPTION
* rename adminDeleteComment to deleteComment
* allow every authenticated user to call this endpoint
* add permission check: either is admin or is author of comment to remove
* introduce ForbiddenException as this is the RESTful response (as we're authorized but just lack the permission, UnauthorizedException doesn't make sense)
* adapt unit tests